### PR TITLE
Add kinfo_proc default value

### DIFF
--- a/IOSSecuritySuite/DebuggerChecker.swift
+++ b/IOSSecuritySuite/DebuggerChecker.swift
@@ -12,6 +12,12 @@ internal class DebuggerChecker {
   // https://developer.apple.com/library/archive/qa/qa1361/_index.html
   static func amIDebugged() -> Bool {
     var kinfo = kinfo_proc()
+
+    // Initialize the flags so that, if sysctl fails for some bizarre
+    // reason, we get a predictable result.
+    // see: https://developer.apple.com/library/archive/qa/qa1361/_index.html
+    kinfo.kp_proc.p_flag = 0
+
     var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid()]
     var size = MemoryLayout<kinfo_proc>.stride
     let sysctlRet = sysctl(&mib, UInt32(mib.count), &kinfo, &size, nil, 0)

--- a/IOSSecuritySuite/ReverseEngineeringToolsChecker.swift
+++ b/IOSSecuritySuite/ReverseEngineeringToolsChecker.swift
@@ -41,8 +41,8 @@ internal class ReverseEngineeringToolsChecker {
       case .openedPorts:
         result = checkOpenedPorts()
       case .pSelectFlag:
-        break
 //        result = checkPSelectFlag()
+        break
       default:
         continue
       }
@@ -136,6 +136,12 @@ internal class ReverseEngineeringToolsChecker {
   // EXPERIMENTAL
   private static func checkPSelectFlag() -> CheckResult {
     var kinfo = kinfo_proc()
+
+    // Initialize the flags so that, if sysctl fails for some bizarre
+    // reason, we get a predictable result.
+    // see: https://developer.apple.com/library/archive/qa/qa1361/_index.html
+    kinfo.kp_proc.p_flag = 0
+
     var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid()]
     var size = MemoryLayout<kinfo_proc>.stride
     let sysctlRet = sysctl(&mib, UInt32(mib.count), &kinfo, &size, nil, 0)


### PR DESCRIPTION
Add default value to kinfo_proc.p_flag to handle eventual error of `sysctl` call.

Note: This **doesn't** fix the reverse engineering detection returning false positive on iOS 18+